### PR TITLE
Add MIDDLEWEIGHT division to fighters section ordering

### DIFF
--- a/app/slices/FightersSection/index.vue
+++ b/app/slices/FightersSection/index.vue
@@ -238,7 +238,14 @@ const searchPlaceholder = computed(
 );
 const loadMoreLabel = computed(() => props.slice.primary.load_more_label || "Load More Fighters");
 
-const divisionOrder = ["BANTAMWEIGHT", "FEATHERWEIGHT", "LIGHTWEIGHT", "WELTERWEIGHT", "HEAVYWEIGHT"];
+const divisionOrder = [
+  "BANTAMWEIGHT",
+  "FEATHERWEIGHT",
+  "LIGHTWEIGHT",
+  "WELTERWEIGHT",
+  "MIDDLEWEIGHT",
+  "HEAVYWEIGHT",
+];
 
 const divisions = computed(() => {
   const uniqueDivisions = Array.from(new Set(fighters.value.map((fighter) => fighter.division)));


### PR DESCRIPTION
## Summary
Added the MIDDLEWEIGHT division to the division ordering array in the FightersSection component to ensure proper sorting and display of fighters across all weight classes.

## Changes
- Added "MIDDLEWEIGHT" to the `divisionOrder` array in the correct position (between WELTERWEIGHT and HEAVYWEIGHT)
- Reformatted the array to use multi-line formatting for improved readability and maintainability

## Details
The division ordering is used to sort fighters by their weight class. This change ensures that fighters in the MIDDLEWEIGHT division are properly categorized and displayed in the correct order alongside other divisions.

https://claude.ai/code/session_01MaVL16Pj8FCuysHDcnhc8M