### PR TITLE
Add mobile viewport detection for event card hover effects

### DIFF
--- a/app/slices/UpcomingEventsGrid/index.vue
+++ b/app/slices/UpcomingEventsGrid/index.vue
@@ -15,11 +15,21 @@ const getTags = (tagsString: string | null | undefined) => {
 
 const sectionRef = ref<HTMLElement | null>(null);
 const isHeaderInView = ref(false);
+const isMobileViewport = ref(false);
 const cardStates = ref<Record<number, boolean>>({});
 let headerObserver: IntersectionObserver | null = null;
 let cardObserver: IntersectionObserver | null = null;
+let mobileViewportQuery: MediaQueryList | null = null;
+
+const handleViewportChange = () => {
+  isMobileViewport.value = mobileViewportQuery?.matches ?? false;
+};
 
 onMounted(async () => {
+  mobileViewportQuery = window.matchMedia("(max-width: 767px)");
+  mobileViewportQuery.addEventListener("change", handleViewportChange);
+  isMobileViewport.value = mobileViewportQuery.matches;
+
   await nextTick();
   if (!sectionRef.value) return;
 
@@ -76,6 +86,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  mobileViewportQuery?.removeEventListener("change", handleViewportChange);
   headerObserver?.disconnect();
   cardObserver?.disconnect();
 });
@@ -122,7 +133,12 @@ onUnmounted(() => {
               loading="lazy"
               decoding="async"
               fetchpriority="low"
-              class="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500 scale-110 group-hover:scale-100"
+              :class="[
+                'w-full h-full object-cover transition-all duration-500',
+                isMobileViewport && cardStates[index]
+                  ? 'grayscale-0 scale-100'
+                  : 'grayscale group-hover:grayscale-0 scale-110 group-hover:scale-100',
+              ]"
               :src="event.image.url"
             >
             <div


### PR DESCRIPTION
## Summary
This PR adds responsive viewport detection to the UpcomingEventsGrid component to handle hover effects appropriately across different screen sizes. On mobile devices, the grayscale and scale animations are now triggered by card state changes rather than hover interactions.

## Key Changes
- Added `isMobileViewport` ref to track whether the current viewport is mobile (max-width: 767px)
- Implemented `handleViewportChange()` function to update mobile viewport state when the viewport is resized
- Set up a MediaQueryList listener in `onMounted()` to detect viewport changes and initialize the mobile state
- Cleaned up the MediaQueryList listener in `onUnmounted()` to prevent memory leaks
- Updated the event card image class binding to conditionally apply hover effects based on viewport type:
  - On mobile: applies grayscale-0 and scale-100 when card is in view (`cardStates[index]`)
  - On desktop: maintains original hover-based grayscale and scale animations

## Implementation Details
- Uses the CSS media query `(max-width: 767px)` to define the mobile breakpoint
- The mobile behavior ties visual effects to the card's intersection observer state rather than CSS hover pseudo-classes, which don't work well on touch devices
- Properly manages event listeners to avoid memory leaks on component unmount

https://claude.ai/code/session_01APEsq6fodGBSWnmW1GNcGA