### PR TITLE
Add Prismic webhook for on-demand edge cache purging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,23 @@ DATABASE_URL="postgres://postgres:postgres@localhost:5432/tfc"
 # Optional. Connections one process may hold open. Defaults to 1 in production
 # (a serverless function scales by cloning, not by pooling) and 10 elsewhere.
 # DATABASE_POOL_MAX=10
+
+# ── Making a Prismic publish show up straight away ──
+# Every marketing page is edge-cached for ten minutes (`route-rules.ts`), so
+# without these an edit waits out the expiry and then one more visitor before
+# anyone sees it. With them, Prismic's webhook purges the pages on publish.
+# Neither is needed locally; `nuxt dev` does not cache pages.
+
+# Shared with the Prismic webhook, and the only guard on an endpoint that
+# re-renders the whole site. Generate with `openssl rand -hex 32`.
+# NUXT_PRISMIC_WEBHOOK_SECRET=""
+
+# Vercel's per-deployment bypass token. Read at build time as well as at
+# runtime, so changing it needs a redeploy, not just a restart. Generate with
+# `openssl rand -hex 32`.
+# NUXT_REVALIDATE_BYPASS_TOKEN=""
+
+# Optional. Where to send the purge requests; defaults to the host Prismic
+# called the webhook on, which is right unless the webhook is aimed at a
+# different domain from the one being refreshed.
+# NUXT_REVALIDATE_ORIGIN="https://tfcgeo.com"

--- a/.env.example
+++ b/.env.example
@@ -7,22 +7,11 @@ DATABASE_URL="postgres://postgres:postgres@localhost:5432/tfc"
 # (a serverless function scales by cloning, not by pooling) and 10 elsewhere.
 # DATABASE_POOL_MAX=10
 
-# ── Making a Prismic publish show up straight away ──
-# Every marketing page is edge-cached for ten minutes (`route-rules.ts`), so
-# without these an edit waits out the expiry and then one more visitor before
-# anyone sees it. With them, Prismic's webhook purges the pages on publish.
-# Neither is needed locally; `nuxt dev` does not cache pages.
-
-# Shared with the Prismic webhook, and the only guard on an endpoint that
-# re-renders the whole site. Generate with `openssl rand -hex 32`.
+# Prismic publish -> edge cache purge. Not needed locally; see README.
+# Both: openssl rand -hex 32
 # NUXT_PRISMIC_WEBHOOK_SECRET=""
-
-# Vercel's per-deployment bypass token. Read at build time as well as at
-# runtime, so changing it needs a redeploy, not just a restart. Generate with
-# `openssl rand -hex 32`.
+# Read at build time as well as at runtime, so changing it needs a redeploy.
 # NUXT_REVALIDATE_BYPASS_TOKEN=""
 
-# Optional. Where to send the purge requests; defaults to the host Prismic
-# called the webhook on, which is right unless the webhook is aimed at a
-# different domain from the one being refreshed.
+# Optional. Defaults to the host Prismic called the webhook on.
 # NUXT_REVALIDATE_ORIGIN="https://tfcgeo.com"

--- a/README.md
+++ b/README.md
@@ -112,3 +112,45 @@ Every server test starts from an empty database; `test/setup/database.ts`
 arranges that, so no test has to remember to. Reach for `test/helpers` to
 arrange state — `createUser()` and friends fill in anything the test is not
 about, so what a test *is* about stays readable.
+
+## Prismic and the edge cache
+
+Pages are edge-cached. `route-rules.ts` puts `isr: 600` over `/**`, so on Vercel
+a page is stored for ten minutes and then refreshed *behind* the next request:
+the visitor who arrives at minute eleven is still served the old HTML, and only
+the one after that sees the new. Each edge region has its own copy, so a publish
+can look like it landed in one place and not another. Nothing is wrong with
+Prismic when that happens — the page just has not been rebuilt yet.
+
+A Prismic webhook fixes it, by purging the pages on publish instead of waiting
+for them to expire. Two variables, both set in the Vercel project:
+
+```bash
+openssl rand -hex 32   # NUXT_PRISMIC_WEBHOOK_SECRET
+openssl rand -hex 32   # NUXT_REVALIDATE_BYPASS_TOKEN
+```
+
+`NUXT_REVALIDATE_BYPASS_TOKEN` is read at **build** time as well as at runtime —
+it is baked into every ISR route's prerender config — so it takes a redeploy to
+change, not just a restart.
+
+Then in Prismic, under *Settings → Webhooks*, add one pointing at
+`https://<the site>/api/prismic/revalidate` with `NUXT_PRISMIC_WEBHOOK_SECRET`
+as its secret. "Trigger it now" answers `{"ok": true, "type": "test-trigger"}`
+if the URL and the secret are right, and purges nothing.
+
+On a real publish the endpoint re-renders every page the site serves from
+Prismic, not just the documents that changed. It has to: the footer is on every
+page, fighters appear in three different slices, and Prismic reports document
+ids rather than URLs, so the pages a publish affects cannot be worked out from
+what it tells us. `server/utils/prismic-paths.ts` holds the map from document
+types to paths — **a new Prismic type with a page of its own has to be added
+there**, or that page will only ever refresh on the ten-minute timer.
+
+One edit the webhook cannot speed up is *unpublishing*: a document that is no
+longer live is not in the query the endpoint runs, so its path is not among the
+ones purged and the page serves its old HTML until the ten minutes are up.
+
+The ten minutes remain the backstop. If the webhook is misconfigured, or Prismic
+never calls it, the site is stale for that long and no longer; the webhook only
+makes it faster, so a mistake here is slow, not broken.

--- a/README.md
+++ b/README.md
@@ -115,42 +115,29 @@ about, so what a test *is* about stays readable.
 
 ## Prismic and the edge cache
 
-Pages are edge-cached. `route-rules.ts` puts `isr: 600` over `/**`, so on Vercel
-a page is stored for ten minutes and then refreshed *behind* the next request:
-the visitor who arrives at minute eleven is still served the old HTML, and only
-the one after that sees the new. Each edge region has its own copy, so a publish
-can look like it landed in one place and not another. Nothing is wrong with
-Prismic when that happens — the page just has not been rebuilt yet.
+`route-rules.ts` puts `isr: 600` over `/**`, so on Vercel a page is stored at
+the edge for ten minutes and then refreshed *behind* the next request — the
+visitor at minute eleven still gets the old HTML. Each region caches
+separately. That, not Prismic, is why an edit can seem not to land.
 
-A Prismic webhook fixes it, by purging the pages on publish instead of waiting
-for them to expire. Two variables, both set in the Vercel project:
+A Prismic webhook purges the pages on publish instead. Set two variables in the
+Vercel project, both `openssl rand -hex 32`:
 
-```bash
-openssl rand -hex 32   # NUXT_PRISMIC_WEBHOOK_SECRET
-openssl rand -hex 32   # NUXT_REVALIDATE_BYPASS_TOKEN
-```
-
-`NUXT_REVALIDATE_BYPASS_TOKEN` is read at **build** time as well as at runtime —
-it is baked into every ISR route's prerender config — so it takes a redeploy to
-change, not just a restart.
+- `NUXT_PRISMIC_WEBHOOK_SECRET`
+- `NUXT_REVALIDATE_BYPASS_TOKEN` — read at **build** time as well as at
+  runtime, so changing it takes a redeploy, not just a restart.
 
 Then in Prismic, under *Settings → Webhooks*, add one pointing at
-`https://<the site>/api/prismic/revalidate` with `NUXT_PRISMIC_WEBHOOK_SECRET`
-as its secret. "Trigger it now" answers `{"ok": true, "type": "test-trigger"}`
-if the URL and the secret are right, and purges nothing.
+`https://<the site>/api/prismic/revalidate` with that secret. "Trigger it now"
+answers `{"ok": true, "type": "test-trigger"}` and purges nothing.
 
-On a real publish the endpoint re-renders every page the site serves from
-Prismic, not just the documents that changed. It has to: the footer is on every
-page, fighters appear in three different slices, and Prismic reports document
-ids rather than URLs, so the pages a publish affects cannot be worked out from
-what it tells us. `server/utils/prismic-paths.ts` holds the map from document
-types to paths — **a new Prismic type with a page of its own has to be added
-there**, or that page will only ever refresh on the ten-minute timer.
+A publish re-renders every page the site serves from Prismic, not just the
+changed documents — the footer is on every page and fighters appear in three
+slices, so the pages one publish affects cannot be worked out from the document
+ids Prismic sends. `server/utils/prismic-paths.ts` maps types to paths, and **a
+new type with a page of its own has to be added there**.
 
-One edit the webhook cannot speed up is *unpublishing*: a document that is no
-longer live is not in the query the endpoint runs, so its path is not among the
-ones purged and the page serves its old HTML until the ten minutes are up.
-
-The ten minutes remain the backstop. If the webhook is misconfigured, or Prismic
-never calls it, the site is stale for that long and no longer; the webhook only
-makes it faster, so a mistake here is slow, not broken.
+Two things the webhook does not cover: unpublishing a document (it is gone from
+the query, so its page waits out the ten minutes), and a misconfigured or
+uncalled webhook. Both fall back on the expiry, so a mistake here is slow, not
+broken.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,39 +26,21 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
-    // Server-only, all three. See `server/api/prismic/revalidate.post.ts`.
-
-    /** Shared with Prismic, and the only guard on the purge endpoint. */
+    // Server-only. See `server/api/prismic/revalidate.post.ts`.
     prismicWebhookSecret: "",
-
-    /**
-     * The deployment's Vercel bypass token, so the purge endpoint can send it
-     * back. It has to match `nitro.vercel.config.bypassToken` below, which is
-     * read at build time — so this is the same variable read twice, once by the
-     * build and once by the running server, and changing it needs a redeploy
-     * rather than only a restart.
-     */
+    // Must match `nitro.vercel.config.bypassToken` below, which is read at
+    // build time — so changing it needs a redeploy, not just a restart.
     revalidateBypassToken: "",
-
-    /**
-     * Where to send the purge requests. Empty means the host Prismic called,
-     * which is what you want unless the webhook is aimed at a different domain
-     * from the one being refreshed.
-     */
+    // Defaults to the host Prismic called the webhook on.
     revalidateOrigin: "",
-
-    /** So the server can query Prismic without going through the Vue plugin. */
     prismicRepository: prismicConfig.repositoryName,
   },
 
   nitro: {
     vercel: {
       config: {
-        // What makes on-demand purging possible at all: the Vercel preset
-        // writes this into the `.prerender-config.json` of every ISR route, and
-        // Vercel then honours `x-prerender-revalidate: <token>` on those routes.
-        // Without it every page is stuck with the ten-minute expiry in
-        // `route-rules.ts` and nothing can shorten it.
+        // The Vercel preset writes this into every ISR route's prerender
+        // config, which is what makes on-demand purging possible at all.
         bypassToken: process.env.NUXT_REVALIDATE_BYPASS_TOKEN,
       },
     },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -25,6 +25,45 @@ export default defineNuxtConfig({
     },
   },
 
+  runtimeConfig: {
+    // Server-only, all three. See `server/api/prismic/revalidate.post.ts`.
+
+    /** Shared with Prismic, and the only guard on the purge endpoint. */
+    prismicWebhookSecret: "",
+
+    /**
+     * The deployment's Vercel bypass token, so the purge endpoint can send it
+     * back. It has to match `nitro.vercel.config.bypassToken` below, which is
+     * read at build time — so this is the same variable read twice, once by the
+     * build and once by the running server, and changing it needs a redeploy
+     * rather than only a restart.
+     */
+    revalidateBypassToken: "",
+
+    /**
+     * Where to send the purge requests. Empty means the host Prismic called,
+     * which is what you want unless the webhook is aimed at a different domain
+     * from the one being refreshed.
+     */
+    revalidateOrigin: "",
+
+    /** So the server can query Prismic without going through the Vue plugin. */
+    prismicRepository: prismicConfig.repositoryName,
+  },
+
+  nitro: {
+    vercel: {
+      config: {
+        // What makes on-demand purging possible at all: the Vercel preset
+        // writes this into the `.prerender-config.json` of every ISR route, and
+        // Vercel then honours `x-prerender-revalidate: <token>` on those routes.
+        // Without it every page is stuck with the ten-minute expiry in
+        // `route-rules.ts` and nothing can shorten it.
+        bypassToken: process.env.NUXT_REVALIDATE_BYPASS_TOKEN,
+      },
+    },
+  },
+
   // The cache boundary lives in ./route-rules.ts so it can be asserted on
   // directly. See ADR-0008.
   routeRules,

--- a/server/api/prismic/revalidate.post.ts
+++ b/server/api/prismic/revalidate.post.ts
@@ -1,0 +1,100 @@
+import { createClient, filter, type WebhookBody } from "@prismicio/client";
+
+/**
+ * The Prismic webhook that makes a publish show up straight away.
+ *
+ * Without it the site is only as fresh as `route-rules.ts` allows: `/**` is
+ * `isr: 600`, so an edit waits out the ten minutes and then one more visitor
+ * before anyone sees it, per edge region. Point a Prismic webhook at
+ * `POST /api/prismic/revalidate` and a publish purges the pages instead of
+ * waiting for them to expire. The ten minutes stay as the backstop for when
+ * this endpoint is misconfigured or Prismic never calls it.
+ *
+ * It lives under `/api`, which `route-rules.ts` exempts from every cache — a
+ * cached purge endpoint would answer the second publish out of the store built
+ * by the first.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event);
+  const body = await readBody<Partial<WebhookBody>>(event);
+
+  // Refuse rather than run unauthenticated. An open endpoint that re-renders
+  // every page on demand is worth more to someone else than it is to us, and
+  // failing loudly here is how a half-finished setup gets noticed.
+  if (!config.prismicWebhookSecret) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "NUXT_PRISMIC_WEBHOOK_SECRET is not set",
+    });
+  }
+
+  if (!webhookSecretMatches(body?.secret, config.prismicWebhookSecret)) {
+    throw createError({ statusCode: 401, statusMessage: "Bad webhook secret" });
+  }
+
+  // Prismic's "Trigger it now" button. Nothing was published, so there is
+  // nothing to purge — but a 200 is what tells whoever pressed it that the URL
+  // and the secret are right, which is the whole reason the button exists.
+  if (body?.type === "test-trigger") {
+    return { ok: true, type: "test-trigger", revalidated: 0, failed: [] };
+  }
+
+  if (!config.revalidateBypassToken) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "NUXT_REVALIDATE_BYPASS_TOKEN is not set",
+    });
+  }
+
+  // Every `api-update` purges everything, including the ones whose `documents`
+  // is empty because only a Release or a custom type moved. Deciding which
+  // publishes are safe to skip means predicting which pages a document appears
+  // on, which is the guess this whole endpoint exists to avoid making — and an
+  // unnecessary purge costs a few seconds of render, while a skipped one is
+  // the stale page we started with.
+  const client = createClient(config.prismicRepository);
+  const documents = await client.dangerouslyGetAll({
+    filters: [filter.any("document.type", COLLECTION_TYPES)],
+    lang: "*",
+  });
+
+  // Note what this cannot reach: a document that was *unpublished* is gone from
+  // the query above, so its path is not in the list and its page keeps serving
+  // the old HTML until the ten minutes run out. Fixing that means keeping our
+  // own record of which id was served at which path, which is a second source
+  // of truth about Prismic's content — a worse thing to own than a ten-minute
+  // wait on the rarest kind of edit.
+  const paths = pathsToRevalidate(documents);
+  const outcomes = await revalidatePaths(paths, {
+    // The host Prismic called us on is the deployment whose cache needs
+    // purging. `NUXT_REVALIDATE_ORIGIN` overrides it for the case where the
+    // webhook is aimed somewhere other than the domain to refresh.
+    origin: config.revalidateOrigin || getRequestURL(event).origin,
+    bypassToken: config.revalidateBypassToken,
+  });
+
+  const failed = outcomes.filter((outcome) => !outcome.ok);
+
+  // Answer 200 even when some paths failed. A non-2xx makes Prismic retry the
+  // publish, which re-renders every page that already succeeded to get at the
+  // few that did not; the report and the log line are the better way to find
+  // out. A failure to reach Prismic at all throws above, and that one *should*
+  // be retried.
+  if (failed.length > 0) {
+    console.error(
+      `[prismic] revalidated ${outcomes.length - failed.length}/${outcomes.length} paths;` +
+        ` failed: ${failed.map((outcome) => `${outcome.path} (${outcome.error ?? outcome.status})`).join(", ")}`,
+    );
+  }
+
+  return {
+    ok: failed.length === 0,
+    type: body?.type ?? null,
+    revalidated: outcomes.length - failed.length,
+    failed: failed.map((outcome) => ({
+      path: outcome.path,
+      status: outcome.status,
+      error: outcome.error,
+    })),
+  };
+});

--- a/server/api/prismic/revalidate.post.ts
+++ b/server/api/prismic/revalidate.post.ts
@@ -1,26 +1,17 @@
 import { createClient, filter, type WebhookBody } from "@prismicio/client";
 
 /**
- * The Prismic webhook that makes a publish show up straight away.
+ * Purges the edge cache when Prismic publishes, instead of waiting out the
+ * ten-minute `isr: 600` in `route-rules.ts` — which stays as the backstop if
+ * this is misconfigured. Point a Prismic webhook at it.
  *
- * Without it the site is only as fresh as `route-rules.ts` allows: `/**` is
- * `isr: 600`, so an edit waits out the ten minutes and then one more visitor
- * before anyone sees it, per edge region. Point a Prismic webhook at
- * `POST /api/prismic/revalidate` and a publish purges the pages instead of
- * waiting for them to expire. The ten minutes stay as the backstop for when
- * this endpoint is misconfigured or Prismic never calls it.
- *
- * It lives under `/api`, which `route-rules.ts` exempts from every cache — a
- * cached purge endpoint would answer the second publish out of the store built
- * by the first.
+ * Under `/api`, which `route-rules.ts` exempts from every cache.
  */
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event);
   const body = await readBody<Partial<WebhookBody>>(event);
 
-  // Refuse rather than run unauthenticated. An open endpoint that re-renders
-  // every page on demand is worth more to someone else than it is to us, and
-  // failing loudly here is how a half-finished setup gets noticed.
+  // Refuse rather than run unauthenticated.
   if (!config.prismicWebhookSecret) {
     throw createError({
       statusCode: 503,
@@ -32,9 +23,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, statusMessage: "Bad webhook secret" });
   }
 
-  // Prismic's "Trigger it now" button. Nothing was published, so there is
-  // nothing to purge — but a 200 is what tells whoever pressed it that the URL
-  // and the secret are right, which is the whole reason the button exists.
+  // Prismic's "Trigger it now" button: nothing published, but a 200 confirms
+  // the URL and the secret.
   if (body?.type === "test-trigger") {
     return { ok: true, type: "test-trigger", revalidated: 0, failed: [] };
   }
@@ -46,40 +36,22 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  // Every `api-update` purges everything, including the ones whose `documents`
-  // is empty because only a Release or a custom type moved. Deciding which
-  // publishes are safe to skip means predicting which pages a document appears
-  // on, which is the guess this whole endpoint exists to avoid making — and an
-  // unnecessary purge costs a few seconds of render, while a skipped one is
-  // the stale page we started with.
   const client = createClient(config.prismicRepository);
   const documents = await client.dangerouslyGetAll({
     filters: [filter.any("document.type", COLLECTION_TYPES)],
     lang: "*",
   });
 
-  // Note what this cannot reach: a document that was *unpublished* is gone from
-  // the query above, so its path is not in the list and its page keeps serving
-  // the old HTML until the ten minutes run out. Fixing that means keeping our
-  // own record of which id was served at which path, which is a second source
-  // of truth about Prismic's content — a worse thing to own than a ten-minute
-  // wait on the rarest kind of edit.
+  // An unpublished document is not in that query, so its page waits out the ten
+  // minutes. Knowing its path would mean keeping our own id-to-path record.
   const paths = pathsToRevalidate(documents);
   const outcomes = await revalidatePaths(paths, {
-    // The host Prismic called us on is the deployment whose cache needs
-    // purging. `NUXT_REVALIDATE_ORIGIN` overrides it for the case where the
-    // webhook is aimed somewhere other than the domain to refresh.
     origin: config.revalidateOrigin || getRequestURL(event).origin,
     bypassToken: config.revalidateBypassToken,
   });
 
   const failed = outcomes.filter((outcome) => !outcome.ok);
 
-  // Answer 200 even when some paths failed. A non-2xx makes Prismic retry the
-  // publish, which re-renders every page that already succeeded to get at the
-  // few that did not; the report and the log line are the better way to find
-  // out. A failure to reach Prismic at all throws above, and that one *should*
-  // be retried.
   if (failed.length > 0) {
     console.error(
       `[prismic] revalidated ${outcomes.length - failed.length}/${outcomes.length} paths;` +
@@ -87,6 +59,7 @@ export default defineEventHandler(async (event) => {
     );
   }
 
+  // 200 even on partial failure: a non-2xx makes Prismic retry the whole purge.
   return {
     ok: failed.length === 0,
     type: body?.type ?? null,

--- a/server/utils/prismic-paths.ts
+++ b/server/utils/prismic-paths.ts
@@ -1,40 +1,18 @@
 /**
- * Every path on this site whose HTML is built from Prismic content.
+ * Every path the site serves from Prismic.
  *
- * The webhook that purges the edge cache (`server/api/prismic/revalidate.post.ts`)
- * needs paths, and Prismic will not give it any: a publish reports which
- * *documents* changed, by id, and says nothing about which pages render them.
- * There is no cheap way back. Most types here are not rendered on a page of
- * their own at all — `footer` is on every page through the layout, `fighter`
- * appears in the `FightersSection` and `FeaturedFighters` slices as well as at
- * `/fighters/:uid`, `media` and `media_type` in `MediaArchive` — so the blast
- * radius of one publish is, in practice, the whole site.
- *
- * So this module answers the question that can be answered exactly: what is
- * every path Prismic content is served at? The webhook purges all of them on
- * every publish. That is more requests per publish than purging one page would
- * be, and it is the version that cannot quietly miss a page — which is the
- * failure the webhook exists to stop.
+ * A publish reports document ids, not URLs, and most types are rendered
+ * somewhere other than a page of their own (the footer on every page, fighters
+ * in three slices), so the webhook purges all of these rather than guessing
+ * which ones changed.
  */
 
-/** The fields of a Prismic document this module reads. */
 export interface DocumentRef {
   type: string;
   uid?: string | null;
 }
 
-/**
- * Pages that exist whatever is in Prismic, and still render Prismic content.
- *
- * These are Nuxt pages rather than documents, so no query returns them. Every
- * one of them renders the `footer` singleton through the default layout, which
- * is on its own enough reason to purge them all on any publish; most render
- * more than that.
- *
- * `/home-page` is the same document as `/`, reachable at a second URL because
- * `app/pages/home-page.vue` exists alongside `app/pages/index.vue`. It is
- * listed because it is a route the site answers, not because it should be.
- */
+/** Nuxt pages, so no query returns them. All render the Prismic footer. */
 export const FIXED_PATHS = [
   "/",
   "/home-page",
@@ -43,40 +21,22 @@ export const FIXED_PATHS = [
   "/terms-of-service",
 ] as const;
 
-/**
- * Singletons, and the one path each is rendered at.
- *
- * Mirrors `prismic.config.json` plus the Nuxt pages that query a singleton
- * directly. Keep them in step: a type missing here is a page that goes stale
- * for the ten minutes ISR allows, with nothing to notice it by.
- */
 const SINGLETON_PATHS: Record<string, string> = {
   home_page: "/",
   privacy_policy: "/privacy-policy",
   terms_of_service: "/terms-of-service",
 };
 
-/**
- * Repeatable types, and the prefix their `uid` hangs off.
- *
- * `page` is the catch-all at `/:uid` from `prismic.config.json`; `fighter` is
- * `app/pages/fighters/[id].vue`, which passes the route param to `getByUID`.
- */
+/** `page` is the catch-all in prismic.config.json; `fighter` is a Nuxt route. */
 const COLLECTION_PREFIXES: Record<string, string> = {
   page: "",
   fighter: "/fighters",
 };
 
-/** The types the webhook has to enumerate to know every path. */
+/** The types the webhook queries to find every path. */
 export const COLLECTION_TYPES = Object.keys(COLLECTION_PREFIXES);
 
-/**
- * The path a document is served at, or `null` if it has no page of its own.
- *
- * `null` is not "nothing to do" — a `footer` or a `media_type` has no path and
- * still changes what other pages render. It only means this document adds no
- * path to the set.
- */
+/** `null` for types with no page of their own — they still change other pages. */
 export function pathForDocument(document: DocumentRef): string | null {
   const singleton = SINGLETON_PATHS[document.type];
   if (singleton !== undefined) {
@@ -91,12 +51,6 @@ export function pathForDocument(document: DocumentRef): string | null {
   return `${prefix}/${document.uid}`;
 }
 
-/**
- * Every path to purge, given every document that has a page of its own.
- *
- * Deduplicated and stable: two documents can resolve to the same path (the same
- * `uid` in two languages), and the caller sends one request per entry.
- */
 export function pathsToRevalidate(documents: Iterable<DocumentRef>): string[] {
   const paths = new Set<string>(FIXED_PATHS);
 

--- a/server/utils/prismic-paths.ts
+++ b/server/utils/prismic-paths.ts
@@ -1,0 +1,111 @@
+/**
+ * Every path on this site whose HTML is built from Prismic content.
+ *
+ * The webhook that purges the edge cache (`server/api/prismic/revalidate.post.ts`)
+ * needs paths, and Prismic will not give it any: a publish reports which
+ * *documents* changed, by id, and says nothing about which pages render them.
+ * There is no cheap way back. Most types here are not rendered on a page of
+ * their own at all — `footer` is on every page through the layout, `fighter`
+ * appears in the `FightersSection` and `FeaturedFighters` slices as well as at
+ * `/fighters/:uid`, `media` and `media_type` in `MediaArchive` — so the blast
+ * radius of one publish is, in practice, the whole site.
+ *
+ * So this module answers the question that can be answered exactly: what is
+ * every path Prismic content is served at? The webhook purges all of them on
+ * every publish. That is more requests per publish than purging one page would
+ * be, and it is the version that cannot quietly miss a page — which is the
+ * failure the webhook exists to stop.
+ */
+
+/** The fields of a Prismic document this module reads. */
+export interface DocumentRef {
+  type: string;
+  uid?: string | null;
+}
+
+/**
+ * Pages that exist whatever is in Prismic, and still render Prismic content.
+ *
+ * These are Nuxt pages rather than documents, so no query returns them. Every
+ * one of them renders the `footer` singleton through the default layout, which
+ * is on its own enough reason to purge them all on any publish; most render
+ * more than that.
+ *
+ * `/home-page` is the same document as `/`, reachable at a second URL because
+ * `app/pages/home-page.vue` exists alongside `app/pages/index.vue`. It is
+ * listed because it is a route the site answers, not because it should be.
+ */
+export const FIXED_PATHS = [
+  "/",
+  "/home-page",
+  "/contact",
+  "/privacy-policy",
+  "/terms-of-service",
+] as const;
+
+/**
+ * Singletons, and the one path each is rendered at.
+ *
+ * Mirrors `prismic.config.json` plus the Nuxt pages that query a singleton
+ * directly. Keep them in step: a type missing here is a page that goes stale
+ * for the ten minutes ISR allows, with nothing to notice it by.
+ */
+const SINGLETON_PATHS: Record<string, string> = {
+  home_page: "/",
+  privacy_policy: "/privacy-policy",
+  terms_of_service: "/terms-of-service",
+};
+
+/**
+ * Repeatable types, and the prefix their `uid` hangs off.
+ *
+ * `page` is the catch-all at `/:uid` from `prismic.config.json`; `fighter` is
+ * `app/pages/fighters/[id].vue`, which passes the route param to `getByUID`.
+ */
+const COLLECTION_PREFIXES: Record<string, string> = {
+  page: "",
+  fighter: "/fighters",
+};
+
+/** The types the webhook has to enumerate to know every path. */
+export const COLLECTION_TYPES = Object.keys(COLLECTION_PREFIXES);
+
+/**
+ * The path a document is served at, or `null` if it has no page of its own.
+ *
+ * `null` is not "nothing to do" — a `footer` or a `media_type` has no path and
+ * still changes what other pages render. It only means this document adds no
+ * path to the set.
+ */
+export function pathForDocument(document: DocumentRef): string | null {
+  const singleton = SINGLETON_PATHS[document.type];
+  if (singleton !== undefined) {
+    return singleton;
+  }
+
+  const prefix = COLLECTION_PREFIXES[document.type];
+  if (prefix === undefined || !document.uid) {
+    return null;
+  }
+
+  return `${prefix}/${document.uid}`;
+}
+
+/**
+ * Every path to purge, given every document that has a page of its own.
+ *
+ * Deduplicated and stable: two documents can resolve to the same path (the same
+ * `uid` in two languages), and the caller sends one request per entry.
+ */
+export function pathsToRevalidate(documents: Iterable<DocumentRef>): string[] {
+  const paths = new Set<string>(FIXED_PATHS);
+
+  for (const document of documents) {
+    const path = pathForDocument(document);
+    if (path !== null) {
+      paths.add(path);
+    }
+  }
+
+  return [...paths];
+}

--- a/server/utils/revalidate.ts
+++ b/server/utils/revalidate.ts
@@ -1,86 +1,49 @@
 /**
  * Purging a path from Vercel's edge cache.
  *
- * Every marketing path is served by an ISR function (`/**: { isr: 600 }` in
- * `route-rules.ts`), so its HTML sits at the edge for ten minutes after it is
- * built and is then refreshed *behind* the next request — the visitor who
- * arrives at minute eleven still gets the old page, and only the one after
- * that gets the new one. Each region caches separately, so a publish can look
- * like it landed in one place and not another. That, and not Prismic, is why
- * an edit does not show up.
- *
- * Vercel's way out is on-demand revalidation: a request carrying the
- * deployment's bypass token skips the cache, re-renders, and stores the result,
- * so the next visitor is served fresh HTML. The token comes from
- * `nitro.vercel.config.bypassToken` in `nuxt.config.ts`, which the Vercel
- * preset writes into the `.prerender-config.json` of every ISR route at build
- * time — so rotating it takes a redeploy, not just an environment variable
- * change.
- *
- * Nothing here is Vercel-only in a way that breaks elsewhere: on any other host
- * the requests are ordinary ones and the header is ignored.
+ * `/**` is `isr: 600`, so a page sits at the edge for ten minutes and is then
+ * refreshed behind the next request. A request carrying the deployment's bypass
+ * token skips the cache and stores a fresh render instead. The token comes from
+ * `nitro.vercel.config.bypassToken`. Other hosts ignore the header.
  */
 
-/** Vercel checks this against the deployment's `bypassToken`. */
 const REVALIDATE_HEADER = "x-prerender-revalidate";
 
 /**
- * How many paths are re-rendered at once.
- *
- * Each request runs a full server render, and the whole purge has to finish
- * inside one function invocation — Prismic is waiting on the response and
- * there is no `waitUntil` on this runtime to hand the work to. Eight is enough
- * to keep a site of this size well inside the limit without asking the
- * deployment to render the whole thing simultaneously.
+ * Each request is a full render, and the whole purge has to fit in one
+ * invocation with Prismic waiting on it.
  */
 const DEFAULT_CONCURRENCY = 8;
 
 export interface RevalidateOptions {
-  /** Where to send the requests, e.g. `https://tfcgeo.com`. */
   origin: string;
-  /** The deployment's `bypassToken`. */
   bypassToken: string;
   concurrency?: number;
-  /** Injected by the tests; production uses the global. */
+  /** Injected by the tests. */
   fetch?: typeof globalThis.fetch;
 }
 
 export interface RevalidateOutcome {
   path: string;
   ok: boolean;
-  /** `null` when the request never got a response. */
   status: number | null;
   error: string | null;
 }
 
-/**
- * Purges one path, reporting failure rather than throwing.
- *
- * One unreachable path must not abandon the rest: a publish that refreshed
- * every page but one is a much better outcome than a publish that stopped at
- * the first error, and the caller needs the whole list to say which happened.
- */
+/** Reports failure rather than throwing, so one bad path cannot strand the rest. */
 async function revalidatePath(
   path: string,
   { origin, bypassToken, fetch: fetchImpl }: Required<Omit<RevalidateOptions, "concurrency">>,
 ): Promise<RevalidateOutcome> {
   try {
     const response = await fetchImpl(new URL(path, origin), {
-      // The response body is thrown away; the point is the re-render it
-      // provokes and the cache entry that replaces.
       method: "HEAD",
       headers: { [REVALIDATE_HEADER]: bypassToken },
-      // A redirect is the deployment answering, which is all that is being
-      // asked. Following it would purge a path that was not requested.
+      // Following one would purge a path that was not asked for.
       redirect: "manual",
     });
 
-    return {
-      path,
-      ok: response.status < 400,
-      status: response.status,
-      error: null,
-    };
+    return { path, ok: response.status < 400, status: response.status, error: null };
   } catch (error) {
     return {
       path,
@@ -91,12 +54,7 @@ async function revalidatePath(
   }
 }
 
-/**
- * Purges every path, at most `concurrency` at a time.
- *
- * Outcomes come back in the order the paths were given, whatever order they
- * finished in, so a caller can read the report against the list it passed.
- */
+/** Outcomes come back in the order the paths were given. */
 export async function revalidatePaths(
   paths: readonly string[],
   options: RevalidateOptions,

--- a/server/utils/revalidate.ts
+++ b/server/utils/revalidate.ts
@@ -1,0 +1,130 @@
+/**
+ * Purging a path from Vercel's edge cache.
+ *
+ * Every marketing path is served by an ISR function (`/**: { isr: 600 }` in
+ * `route-rules.ts`), so its HTML sits at the edge for ten minutes after it is
+ * built and is then refreshed *behind* the next request — the visitor who
+ * arrives at minute eleven still gets the old page, and only the one after
+ * that gets the new one. Each region caches separately, so a publish can look
+ * like it landed in one place and not another. That, and not Prismic, is why
+ * an edit does not show up.
+ *
+ * Vercel's way out is on-demand revalidation: a request carrying the
+ * deployment's bypass token skips the cache, re-renders, and stores the result,
+ * so the next visitor is served fresh HTML. The token comes from
+ * `nitro.vercel.config.bypassToken` in `nuxt.config.ts`, which the Vercel
+ * preset writes into the `.prerender-config.json` of every ISR route at build
+ * time — so rotating it takes a redeploy, not just an environment variable
+ * change.
+ *
+ * Nothing here is Vercel-only in a way that breaks elsewhere: on any other host
+ * the requests are ordinary ones and the header is ignored.
+ */
+
+/** Vercel checks this against the deployment's `bypassToken`. */
+const REVALIDATE_HEADER = "x-prerender-revalidate";
+
+/**
+ * How many paths are re-rendered at once.
+ *
+ * Each request runs a full server render, and the whole purge has to finish
+ * inside one function invocation — Prismic is waiting on the response and
+ * there is no `waitUntil` on this runtime to hand the work to. Eight is enough
+ * to keep a site of this size well inside the limit without asking the
+ * deployment to render the whole thing simultaneously.
+ */
+const DEFAULT_CONCURRENCY = 8;
+
+export interface RevalidateOptions {
+  /** Where to send the requests, e.g. `https://tfcgeo.com`. */
+  origin: string;
+  /** The deployment's `bypassToken`. */
+  bypassToken: string;
+  concurrency?: number;
+  /** Injected by the tests; production uses the global. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface RevalidateOutcome {
+  path: string;
+  ok: boolean;
+  /** `null` when the request never got a response. */
+  status: number | null;
+  error: string | null;
+}
+
+/**
+ * Purges one path, reporting failure rather than throwing.
+ *
+ * One unreachable path must not abandon the rest: a publish that refreshed
+ * every page but one is a much better outcome than a publish that stopped at
+ * the first error, and the caller needs the whole list to say which happened.
+ */
+async function revalidatePath(
+  path: string,
+  { origin, bypassToken, fetch: fetchImpl }: Required<Omit<RevalidateOptions, "concurrency">>,
+): Promise<RevalidateOutcome> {
+  try {
+    const response = await fetchImpl(new URL(path, origin), {
+      // The response body is thrown away; the point is the re-render it
+      // provokes and the cache entry that replaces.
+      method: "HEAD",
+      headers: { [REVALIDATE_HEADER]: bypassToken },
+      // A redirect is the deployment answering, which is all that is being
+      // asked. Following it would purge a path that was not requested.
+      redirect: "manual",
+    });
+
+    return {
+      path,
+      ok: response.status < 400,
+      status: response.status,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      path,
+      ok: false,
+      status: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Purges every path, at most `concurrency` at a time.
+ *
+ * Outcomes come back in the order the paths were given, whatever order they
+ * finished in, so a caller can read the report against the list it passed.
+ */
+export async function revalidatePaths(
+  paths: readonly string[],
+  options: RevalidateOptions,
+): Promise<RevalidateOutcome[]> {
+  const {
+    origin,
+    bypassToken,
+    concurrency = DEFAULT_CONCURRENCY,
+    fetch: fetchImpl = globalThis.fetch,
+  } = options;
+
+  const outcomes: RevalidateOutcome[] = Array.from({ length: paths.length });
+  let next = 0;
+
+  async function worker() {
+    for (let index = next++; index < paths.length; index = next++) {
+      const path = paths[index];
+      if (path === undefined) {
+        return;
+      }
+
+      outcomes[index] = await revalidatePath(path, { origin, bypassToken, fetch: fetchImpl });
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(Math.max(concurrency, 1), paths.length) }, worker),
+  );
+
+  return outcomes;
+}

--- a/server/utils/webhook-secret.ts
+++ b/server/utils/webhook-secret.ts
@@ -1,0 +1,26 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+/**
+ * Whether a Prismic webhook carried the secret configured for this deployment.
+ *
+ * The endpoint behind this re-renders every page on the site, so an unguarded
+ * one is a free way to make the deployment do arbitrary work; Prismic's own
+ * shared secret in the request body is the only thing standing in front of it.
+ * Prismic sends it in the JSON body rather than as a signature, so there is
+ * nothing to verify against — only a comparison to get right.
+ *
+ * Both sides are hashed first so the comparison is over two 32-byte digests
+ * whatever the inputs were: `timingSafeEqual` throws on a length mismatch, and
+ * bailing out early on length is itself a signal about the secret.
+ */
+export function webhookSecretMatches(provided: unknown, expected: string): boolean {
+  if (typeof provided !== "string" || expected.length === 0) {
+    return false;
+  }
+
+  return timingSafeEqual(sha256(provided), sha256(expected));
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value, "utf8").digest();
+}

--- a/server/utils/webhook-secret.ts
+++ b/server/utils/webhook-secret.ts
@@ -1,17 +1,11 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 
 /**
- * Whether a Prismic webhook carried the secret configured for this deployment.
+ * The only guard on an endpoint that re-renders the whole site. Prismic sends
+ * the shared secret in the body, so there is no signature to verify.
  *
- * The endpoint behind this re-renders every page on the site, so an unguarded
- * one is a free way to make the deployment do arbitrary work; Prismic's own
- * shared secret in the request body is the only thing standing in front of it.
- * Prismic sends it in the JSON body rather than as a signature, so there is
- * nothing to verify against — only a comparison to get right.
- *
- * Both sides are hashed first so the comparison is over two 32-byte digests
- * whatever the inputs were: `timingSafeEqual` throws on a length mismatch, and
- * bailing out early on length is itself a signal about the secret.
+ * Both sides are hashed first: `timingSafeEqual` throws on a length mismatch,
+ * and returning early on length is itself a signal.
  */
 export function webhookSecretMatches(provided: unknown, expected: string): boolean {
   if (typeof provided !== "string" || expected.length === 0) {

--- a/test/unit/prismic-paths.test.ts
+++ b/test/unit/prismic-paths.test.ts
@@ -23,9 +23,7 @@ describe("the path a document is served at", () => {
     expect(pathForDocument({ type: "fighter", uid: "giorgi" })).toBe("/fighters/giorgi");
   });
 
-  // These are rendered inside other pages — the footer by the layout, media by
-  // the MediaArchive slice — so they have no path of their own. The purge still
-  // reaches them, because it covers every page.
+  // Rendered inside other pages, so no path of their own.
   it.each(["footer", "media", "media_type", "cta", "picture", "discipline", "division"])(
     "gives %s no path of its own",
     (type) => {
@@ -54,9 +52,7 @@ describe("the set of paths a publish purges", () => {
     expect(paths).toContain("/fighters/giorgi");
   });
 
-  // A `uid` is unique per type per language, so the same page in two languages
-  // arrives as two documents claiming one path. Sending the request twice would
-  // pay for the render twice.
+  // The same page in two languages is two documents claiming one path.
   it("lists a path once when two documents resolve to it", () => {
     const paths = pathsToRevalidate([
       { type: "page", uid: "about" },
@@ -73,11 +69,7 @@ describe("the set of paths a publish purges", () => {
   });
 });
 
-/**
- * The webhook queries exactly these types to build its path list, so a
- * repeatable type that resolves to a path and is not queried is a page nothing
- * ever purges.
- */
+// A type that resolves to a path and is not queried is a page nothing purges.
 describe("the types the webhook queries", () => {
   it.each(["page", "fighter"])("includes %s, which has a path per document", (type) => {
     expect(COLLECTION_TYPES).toContain(type);

--- a/test/unit/prismic-paths.test.ts
+++ b/test/unit/prismic-paths.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  COLLECTION_TYPES,
+  FIXED_PATHS,
+  pathForDocument,
+  pathsToRevalidate,
+} from "../../server/utils/prismic-paths";
+
+describe("the path a document is served at", () => {
+  it.each([
+    ["home_page", "/"],
+    ["privacy_policy", "/privacy-policy"],
+    ["terms_of_service", "/terms-of-service"],
+  ])("puts the %s singleton at %s", (type, path) => {
+    expect(pathForDocument({ type })).toBe(path);
+  });
+
+  it("puts a page at the catch-all route from prismic.config.json", () => {
+    expect(pathForDocument({ type: "page", uid: "about" })).toBe("/about");
+  });
+
+  it("puts a fighter under /fighters, where app/pages/fighters/[id].vue reads it", () => {
+    expect(pathForDocument({ type: "fighter", uid: "giorgi" })).toBe("/fighters/giorgi");
+  });
+
+  // These are rendered inside other pages — the footer by the layout, media by
+  // the MediaArchive slice — so they have no path of their own. The purge still
+  // reaches them, because it covers every page.
+  it.each(["footer", "media", "media_type", "cta", "picture", "discipline", "division"])(
+    "gives %s no path of its own",
+    (type) => {
+      expect(pathForDocument({ type, uid: "anything" })).toBeNull();
+    },
+  );
+
+  it("gives a repeatable document with no uid no path, rather than a broken one", () => {
+    expect(pathForDocument({ type: "page", uid: null })).toBeNull();
+    expect(pathForDocument({ type: "fighter" })).toBeNull();
+  });
+});
+
+describe("the set of paths a publish purges", () => {
+  it("always covers the pages that are not documents", () => {
+    expect(pathsToRevalidate([])).toEqual([...FIXED_PATHS]);
+  });
+
+  it("covers every document that has a page", () => {
+    const paths = pathsToRevalidate([
+      { type: "page", uid: "about" },
+      { type: "fighter", uid: "giorgi" },
+    ]);
+
+    expect(paths).toContain("/about");
+    expect(paths).toContain("/fighters/giorgi");
+  });
+
+  // A `uid` is unique per type per language, so the same page in two languages
+  // arrives as two documents claiming one path. Sending the request twice would
+  // pay for the render twice.
+  it("lists a path once when two documents resolve to it", () => {
+    const paths = pathsToRevalidate([
+      { type: "page", uid: "about" },
+      { type: "page", uid: "about" },
+      { type: "home_page" },
+    ]);
+
+    expect(paths).toEqual([...new Set(paths)]);
+    expect(paths.filter((path) => path === "/")).toHaveLength(1);
+  });
+
+  it("keeps the fixed paths even when a document lands on one of them", () => {
+    expect(pathsToRevalidate([{ type: "home_page" }])).toEqual([...FIXED_PATHS]);
+  });
+});
+
+/**
+ * The webhook queries exactly these types to build its path list, so a
+ * repeatable type that resolves to a path and is not queried is a page nothing
+ * ever purges.
+ */
+describe("the types the webhook queries", () => {
+  it.each(["page", "fighter"])("includes %s, which has a path per document", (type) => {
+    expect(COLLECTION_TYPES).toContain(type);
+  });
+
+  it("does not include singletons, whose paths are already fixed", () => {
+    expect(COLLECTION_TYPES).not.toContain("home_page");
+    expect(COLLECTION_TYPES).not.toContain("privacy_policy");
+  });
+
+  it("resolves a path for every type it queries", () => {
+    for (const type of COLLECTION_TYPES) {
+      expect(pathForDocument({ type, uid: "a-uid" })).not.toBeNull();
+    }
+  });
+});

--- a/test/unit/revalidate.test.ts
+++ b/test/unit/revalidate.test.ts
@@ -5,7 +5,6 @@ import { webhookSecretMatches } from "../../server/utils/webhook-secret";
 const BYPASS_TOKEN = "a-bypass-token";
 const ORIGIN = "https://tfcgeo.com";
 
-/** A stand-in for `fetch`, typed as one so the recorded calls are too. */
 function respondWith(status = 200) {
   return vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status }));
 }
@@ -24,11 +23,8 @@ describe("purging a path", () => {
     expect(String(fetch.mock.calls[0]?.[0])).toBe(`${ORIGIN}/fighters/giorgi`);
   });
 
-  /**
-   * The whole mechanism is this header. Without it the request is answered from
-   * the very cache entry it was meant to replace, and the purge silently does
-   * nothing at all — which looks exactly like success.
-   */
+  // Without it the request is answered from the cache entry it meant to
+  // replace, and the purge silently does nothing.
   it("carries the bypass token Vercel checks", async () => {
     const fetch = respondWith();
 
@@ -69,11 +65,6 @@ describe("purging a path", () => {
 });
 
 describe("purging every path", () => {
-  /**
-   * The reason one path is reported rather than thrown: a publish that
-   * refreshed every page but one is a far better outcome than one that stopped
-   * at the first failure and left the rest stale.
-   */
   it("keeps going after a path fails, and says which one did", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async (url) =>
       String(url).endsWith("/contact") ? Promise.reject(new Error("boom")) : new Response(null),
@@ -114,10 +105,7 @@ describe("purging every path", () => {
     expect(outcomes.map((outcome) => outcome.path)).toEqual(paths);
   });
 
-  /**
-   * The purge has to finish inside one function invocation with Prismic waiting
-   * on it. Rendering the whole site at once is how that runs out of time.
-   */
+  // The purge has to finish in one invocation with Prismic waiting on it.
   it("never has more than `concurrency` renders in flight", async () => {
     let inFlight = 0;
     let peak = 0;
@@ -153,10 +141,6 @@ describe("purging every path", () => {
   });
 });
 
-/**
- * The endpoint re-renders every page on the site, so this comparison is the
- * only thing between a stranger and an unlimited amount of our compute.
- */
 describe("the webhook secret", () => {
   it("accepts the configured secret", () => {
     expect(webhookSecretMatches("s3cret", "s3cret")).toBe(true);
@@ -171,14 +155,12 @@ describe("the webhook secret", () => {
     expect(webhookSecretMatches(provided, "s3cret")).toBe(false);
   });
 
-  // Prismic sends `null` when no secret is configured on its side, and a body
-  // that was never JSON gives no field at all.
+  // Prismic sends `null` when no secret is configured on its side.
   it.each([[null], [undefined], [123], [{}]])("rejects %s, which is not a secret", (provided) => {
     expect(webhookSecretMatches(provided, "s3cret")).toBe(false);
   });
 
-  // Otherwise a deployment that forgot the variable would accept every caller
-  // that also sent nothing.
+  // Or a deployment missing the variable would accept a caller sending nothing.
   it("rejects everything when no secret is configured", () => {
     expect(webhookSecretMatches("", "")).toBe(false);
     expect(webhookSecretMatches("anything", "")).toBe(false);

--- a/test/unit/revalidate.test.ts
+++ b/test/unit/revalidate.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import { revalidatePaths } from "../../server/utils/revalidate";
+import { webhookSecretMatches } from "../../server/utils/webhook-secret";
+
+const BYPASS_TOKEN = "a-bypass-token";
+const ORIGIN = "https://tfcgeo.com";
+
+/** A stand-in for `fetch`, typed as one so the recorded calls are too. */
+function respondWith(status = 200) {
+  return vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status }));
+}
+
+describe("purging a path", () => {
+  it("asks the deployment for the page, at the origin it was given", async () => {
+    const fetch = respondWith();
+
+    await revalidatePaths(["/fighters/giorgi"], {
+      origin: ORIGIN,
+      bypassToken: BYPASS_TOKEN,
+      fetch,
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(String(fetch.mock.calls[0]?.[0])).toBe(`${ORIGIN}/fighters/giorgi`);
+  });
+
+  /**
+   * The whole mechanism is this header. Without it the request is answered from
+   * the very cache entry it was meant to replace, and the purge silently does
+   * nothing at all — which looks exactly like success.
+   */
+  it("carries the bypass token Vercel checks", async () => {
+    const fetch = respondWith();
+
+    await revalidatePaths(["/"], { origin: ORIGIN, bypassToken: BYPASS_TOKEN, fetch });
+
+    expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get("x-prerender-revalidate")).toBe(
+      BYPASS_TOKEN,
+    );
+  });
+
+  it("does not ask for a body it throws away", async () => {
+    const fetch = respondWith();
+
+    await revalidatePaths(["/"], { origin: ORIGIN, bypassToken: BYPASS_TOKEN, fetch });
+
+    expect(fetch.mock.calls[0]?.[1]?.method).toBe("HEAD");
+  });
+
+  it("counts a redirect as done, because the deployment answered", async () => {
+    const [outcome] = await revalidatePaths(["/"], {
+      origin: ORIGIN,
+      bypassToken: BYPASS_TOKEN,
+      fetch: respondWith(308),
+    });
+
+    expect(outcome?.ok).toBe(true);
+  });
+
+  it("counts an error status as not done", async () => {
+    const [outcome] = await revalidatePaths(["/"], {
+      origin: ORIGIN,
+      bypassToken: BYPASS_TOKEN,
+      fetch: respondWith(500),
+    });
+
+    expect(outcome).toMatchObject({ path: "/", ok: false, status: 500 });
+  });
+});
+
+describe("purging every path", () => {
+  /**
+   * The reason one path is reported rather than thrown: a publish that
+   * refreshed every page but one is a far better outcome than one that stopped
+   * at the first failure and left the rest stale.
+   */
+  it("keeps going after a path fails, and says which one did", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (url) =>
+      String(url).endsWith("/contact") ? Promise.reject(new Error("boom")) : new Response(null),
+    );
+
+    const outcomes = await revalidatePaths(["/", "/contact", "/about"], {
+      origin: ORIGIN,
+      bypassToken: BYPASS_TOKEN,
+      fetch,
+    });
+
+    expect(outcomes.filter((outcome) => outcome.ok).map((outcome) => outcome.path)).toEqual([
+      "/",
+      "/about",
+    ]);
+    expect(outcomes.find((outcome) => !outcome.ok)).toMatchObject({
+      path: "/contact",
+      status: null,
+      error: "boom",
+    });
+  });
+
+  it("reports outcomes in the order the paths were given", async () => {
+    const paths = ["/", "/a", "/b", "/c", "/d"];
+    const fetch = vi.fn<typeof globalThis.fetch>(async (url) => {
+      // Finish in a different order from the one asked for.
+      await new Promise((resolve) => setTimeout(resolve, 20 - String(url).length));
+
+      return new Response(null);
+    });
+
+    const outcomes = await revalidatePaths(paths, {
+      origin: ORIGIN,
+      bypassToken: BYPASS_TOKEN,
+      fetch,
+    });
+
+    expect(outcomes.map((outcome) => outcome.path)).toEqual(paths);
+  });
+
+  /**
+   * The purge has to finish inside one function invocation with Prismic waiting
+   * on it. Rendering the whole site at once is how that runs out of time.
+   */
+  it("never has more than `concurrency` renders in flight", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => {
+      peak = Math.max(peak, ++inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight--;
+
+      return new Response(null);
+    });
+
+    await revalidatePaths(
+      Array.from({ length: 20 }, (_, index) => `/page-${index}`),
+      {
+        origin: ORIGIN,
+        bypassToken: BYPASS_TOKEN,
+        concurrency: 3,
+        fetch,
+      },
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(20);
+    expect(peak).toBe(3);
+  });
+
+  it("does nothing, rather than hanging, when there is nothing to purge", async () => {
+    const fetch = respondWith();
+
+    await expect(
+      revalidatePaths([], { origin: ORIGIN, bypassToken: BYPASS_TOKEN, fetch }),
+    ).resolves.toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The endpoint re-renders every page on the site, so this comparison is the
+ * only thing between a stranger and an unlimited amount of our compute.
+ */
+describe("the webhook secret", () => {
+  it("accepts the configured secret", () => {
+    expect(webhookSecretMatches("s3cret", "s3cret")).toBe(true);
+  });
+
+  it.each([
+    ["a different secret", "nope"],
+    ["a prefix of it", "s3cre"],
+    ["the secret with more on the end", "s3cretand"],
+    ["nothing", ""],
+  ])("rejects %s", (_description, provided) => {
+    expect(webhookSecretMatches(provided, "s3cret")).toBe(false);
+  });
+
+  // Prismic sends `null` when no secret is configured on its side, and a body
+  // that was never JSON gives no field at all.
+  it.each([[null], [undefined], [123], [{}]])("rejects %s, which is not a secret", (provided) => {
+    expect(webhookSecretMatches(provided, "s3cret")).toBe(false);
+  });
+
+  // Otherwise a deployment that forgot the variable would accept every caller
+  // that also sent nothing.
+  it("rejects everything when no secret is configured", () => {
+    expect(webhookSecretMatches("", "")).toBe(false);
+    expect(webhookSecretMatches("anything", "")).toBe(false);
+  });
+});

--- a/test/unit/route-rules.test.ts
+++ b/test/unit/route-rules.test.ts
@@ -36,8 +36,6 @@ describe("routes that read a session", () => {
     "/api",
     "/api/health",
     "/api/entries",
-    // The Prismic purge endpoint. Served from a cache, the second publish
-    // would be answered out of the store the first one built.
     "/api/prismic/revalidate",
     "/predictions",
     "/predictions/tfc-12",

--- a/test/unit/route-rules.test.ts
+++ b/test/unit/route-rules.test.ts
@@ -36,6 +36,9 @@ describe("routes that read a session", () => {
     "/api",
     "/api/health",
     "/api/entries",
+    // The Prismic purge endpoint. Served from a cache, the second publish
+    // would be answered out of the store the first one built.
+    "/api/prismic/revalidate",
     "/predictions",
     "/predictions/tfc-12",
     "/profile",


### PR DESCRIPTION
Implements on-demand edge cache purging when Prismic publishes content, eliminating the need to wait for the 10-minute ISR expiry.

## Summary
When content is published in Prismic, a webhook now triggers cache purification on Vercel's edge network. This ensures published changes appear immediately rather than waiting up to 10 minutes for the ISR (Incremental Static Regeneration) cache to expire.

## Key Changes

- **Webhook endpoint** (`server/api/prismic/revalidate.post.ts`): Receives Prismic publish events, validates the webhook secret, queries all published documents, and triggers cache purging for affected paths.

- **Path mapping** (`server/utils/prismic-paths.ts`): Maps Prismic document types to their corresponding URL paths. Handles both singleton pages (home, privacy policy, etc.) and collection types (pages, fighters). Always purges fixed paths since the footer appears on every page and fighters appear in multiple slices.

- **Cache purging** (`server/utils/revalidate.ts`): Makes HEAD requests to each path with Vercel's `x-prerender-revalidate` bypass token, skipping the cache and forcing a fresh render. Implements concurrent request limiting (default 8) to avoid overwhelming the deployment, with proper error handling that doesn't strand remaining paths if one fails.

- **Webhook secret validation** (`server/utils/webhook-secret.ts`): Uses timing-safe comparison to prevent timing attacks when validating the shared secret between Prismic and the deployment.

- **Configuration**: Added three new runtime config variables (`prismicWebhookSecret`, `revalidateBypassToken`, `revalidateOrigin`) and Nitro Vercel config for the bypass token. The bypass token must be set at build time since it's written into ISR route configuration.

- **Tests**: Comprehensive unit tests covering path resolution, concurrent purging behavior, error handling, and webhook secret validation.

## Notable Details

- The webhook purges all paths rather than trying to infer which ones changed, since most Prismic types (footer, media, CTAs) are rendered on multiple pages.
- Unpublished documents and misconfigured webhooks gracefully fall back to the 10-minute ISR expiry.
- The endpoint returns 200 even on partial failures to prevent Prismic from retrying the entire purge.
- Concurrent requests are limited to prevent resource exhaustion in serverless environments.

https://claude.ai/code/session_01Uq8ZpFE58QzZ1Pab9EhcTU