### PR TITLE
fix: build for Vercel, not for a node server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,12 @@ jobs:
         run: vercel pull --yes --environment="$VERCEL_TARGET" --token="$VERCEL_TOKEN"
 
       - name: Build
+        env:
+          # Nitro picks its preset from the environment, and the build runs
+          # here rather than on Vercel. Without this it writes the node-server
+          # output to `.output/`, and the CLI then fails looking for a `dist`
+          # the Build Output API was supposed to have replaced.
+          NITRO_PRESET: vercel
         run: vercel build $PROD_FLAG --token="$VERCEL_TOKEN"
 
       # Between the build and the deploy, deliberately. A build that fails must

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,10 +87,6 @@ jobs:
 
       - name: Build
         env:
-          # Nitro picks its preset from the environment, and the build runs
-          # here rather than on Vercel. Without this it writes the node-server
-          # output to `.output/`, and the CLI then fails looking for a `dist`
-          # the Build Output API was supposed to have replaced.
           NITRO_PRESET: vercel
         run: vercel build $PROD_FLAG --token="$VERCEL_TOKEN"
 


### PR DESCRIPTION
The first real deploy off `dev` ran the whole pipeline — preflight, database guard, install, `vercel pull` — and then failed at the build:

```
Error: No Output Directory named "dist" found after the Build completed.
```

Nitro had written `.output/server/index.mjs`, which is the **node-server** preset. It picks its target from the environment, and `vercel build` on a GitHub runner does not set one the way a build on Vercel's own infrastructure does — so the CLI went looking for a plain output directory instead of the `.vercel/output` the Build Output API expects.

`NITRO_PRESET=vercel` is the same knob `route-rules.ts` already documents for inspecting what the Vercel preset emits.

Worth confirming separately: that the project's Framework Preset in Vercel says Nuxt.js. This fix does not depend on it, but a wrong preset would be worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kMcEXbiqt1KiTjd66HXP7